### PR TITLE
fix: height jumping when multiple instances of same DWChart embedded on one page

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,26 +2,27 @@ import React, { useEffect, useState, useCallback, useRef } from 'react'
 import PropTypes from 'prop-types'
 
 export default function DWChart({ title, src, ...props }) {
-  const id = src.split('/').filter((str, i) => str.length === 5 && !!i)
   const iframeRef = useRef()
   const [height, setState] = useState(500)
 
   const onMessage = useCallback(
     ({ data = {}, source }) => {
-      if (typeof data === 'string' || source !== iframeRef.current.contentWindow) return
+      if (
+        source !== iframeRef.current.contentWindow ||
+        typeof data === 'string' ||
+        !data['datawrapper-height']
+      )
+        return
 
-      const height = data['datawrapper-height'] && data['datawrapper-height'][id]
-      if (height) {
-        setState(height)
-      }
+      setState(Object.values(data['datawrapper-height'])[0])
     },
-    [id, setState, iframeRef]
+    [setState, iframeRef]
   )
 
   useEffect(() => {
     window.addEventListener('message', onMessage)
     return () => window.removeEventListener('message', onMessage)
-  }, [id, height, setState, onMessage])
+  }, [height, setState, onMessage])
 
   return (
     <iframe


### PR DESCRIPTION
### Motivation
In the current implementation, requested heights received via postmessage will be applied to the iframe, **if the id of the chart matches the id in the height message**. This causes problems when multiple instances of the same chart, requiring different heights, are included on the same page.

In such a case you can see the height 'jumping' between the two alternatives, which looks like this:

![resize-flicker](https://user-images.githubusercontent.com/19191012/125395241-38fdc500-e3ab-11eb-8950-327e65f0c54d.gif)

### Changes
Rewrite as component, to enable use of refs, then only apply height to component iframe, if the message `source` is the same as the ref iframe's `contentWindow`. Equivalent change was made in Datawrapper's own resizing script in [datawrapper/chart-core#120](https://github.com/datawrapper/chart-core/pull/120)

p.s this is basically the first react code I've ever written so not sure how this looks in terms of best practices :D 