### PR TITLE
chore: update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "react-dom": "~16.13.1"
   },
   "peerDependencies": {
-    "react": "^16.8"
+    "react": "^16.8 - ^18"
   },
   "eslintConfig": {
     "parser": "babel-eslint"


### PR DESCRIPTION
allow react versions ^16.8 - ^18 as peerDependencies to avoid conflicts when using with a higher react version than 16